### PR TITLE
Match environments based on factors

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,16 @@
+0.2 (TBD)
++++++++++
+
+* Choose testenvs from ``tox.ini`` by matching factors.
+  - This is a slightly *backward incompatible* change
+  - If a Python version isn't declared in the ``tox.ini``,
+    it may not be run.
+  - Additional envs may be run if they also match the factors,
+    for example, ``py34-django17`` and ``py34-django18`` will
+    both match the default for Python 3.4 (``py34``).
+  - Factor matching extends to overrides set in ``tox.ini``.
+
+
 0.1 (2015-05-21)
 ++++++++++++++++
 

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,10 @@ Configure the Python versions to test with in ``travis.yml``:
     script: tox
 
 And it will run the appropriate testenvs,
-which are ``py27`` and ``py34`` in the example above.
+which by default are any declared env with
+``py27`` or ``py34`` as factors of the name.
+If no environments match a given factor,
+the ``py27`` or ``py34`` envs are used as a fallback.
 
 
 Advanced Configuration
@@ -39,8 +42,11 @@ to run under which versions of Python:
     envlist = py{27,34}-django{17,18}, docs
 
     [tox:travis]
-    2.7 = py27-django{17,18}
-    3.4 = py34-django{17,18}, docs
+    2.7 = py27
+    3.4 = py34, docs
+
+This would run the Python 2.7 variants under 2.7,
+and the Python 3.4 variants and the ``docs`` env under 3.4.
 
 Note that Travis won't run all the envs simultaneously,
 because it's build matrix is only aware of the Python versions.

--- a/test_tox_travis.py
+++ b/test_tox_travis.py
@@ -33,18 +33,21 @@ envlist = py{27,34}-django, other
 
 
 class TestToxTravis:
+    def tox_envs(self):
+        output = subprocess.Popen(
+            ['tox', '-l'], stdout=subprocess.PIPE).communicate()[0]
+        return set(output.decode('utf-8').strip().split())
+
     def test_not_travis(self, tmpdir):
         os.chdir(str(tmpdir))
         tmpdir.join('tox.ini').write(tox_ini)
 
-        output = subprocess.check_output(['tox', '-l'])
-        expected = '\n'.join([
-            'py26', 'py27',
-            'py32', 'py33', 'py34',
-            'pypy', 'pypy3',
-            'docs'
-        ]) + '\n'  # Expect a trailing newline
-        assert output.decode('utf-8') == expected
+        expected = set([
+            'py26', 'py27', 'py32', 'py33', 'py34',
+            'pypy', 'pypy3', 'docs',
+        ])
+
+        assert self.tox_envs() == expected
 
     def test_travis_default_26(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -52,8 +55,8 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.6')
-        output = subprocess.check_output(['tox', '-l'])
-        assert output.decode('utf-8') == 'py26\n'
+
+        assert self.tox_envs() == set(['py26'])
 
     def test_travis_default_27(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -61,8 +64,8 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
-        output = subprocess.check_output(['tox', '-l'])
-        assert output.decode('utf-8') == 'py27\n'
+
+        assert self.tox_envs() == set(['py27'])
 
     def test_travis_default_32(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -70,8 +73,8 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.2')
-        output = subprocess.check_output(['tox', '-l'])
-        assert output.decode('utf-8') == 'py32\n'
+
+        assert self.tox_envs() == set(['py32'])
 
     def test_travis_default_33(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -79,8 +82,8 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.3')
-        output = subprocess.check_output(['tox', '-l'])
-        assert output.decode('utf-8') == 'py33\n'
+
+        assert self.tox_envs() == set(['py33'])
 
     def test_travis_default_34(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -88,8 +91,8 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.4')
-        output = subprocess.check_output(['tox', '-l'])
-        assert output.decode('utf-8') == 'py34\n'
+
+        assert self.tox_envs() == set(['py34'])
 
     def test_travis_default_pypy(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -97,8 +100,8 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', 'pypy')
-        output = subprocess.check_output(['tox', '-l'])
-        assert output.decode('utf-8') == 'pypy\n'
+
+        assert self.tox_envs() == set(['pypy'])
 
     def test_travis_default_pypy3(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -106,8 +109,8 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', 'pypy3')
-        output = subprocess.check_output(['tox', '-l'])
-        assert output.decode('utf-8') == 'pypy3\n'
+
+        assert self.tox_envs() == set(['pypy3'])
 
     def test_travis_override(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -115,8 +118,8 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
-        output = subprocess.check_output(['tox', '-l'])
-        assert output.decode('utf-8') == 'py27\ndocs\n'
+
+        assert self.tox_envs() == set(['py27', 'docs'])
 
     def test_respect_overridden_toxenv(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -125,8 +128,8 @@ class TestToxTravis:
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
         monkeypatch.setenv('TOXENV', 'py32')
-        output = subprocess.check_output(['tox', '-l'])
-        assert output.decode('utf-8') == 'py32\n'
+
+        assert self.tox_envs() == set(['py32'])
 
     def test_keep_if_no_match(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -134,8 +137,8 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
-        output = subprocess.check_output(['tox', '-l'])
-        assert output.decode('utf-8') == 'py27\n'
+
+        assert self.tox_envs() == set(['py27'])
 
     def test_default_tox_ini_overrides(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -143,8 +146,8 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
-        output = subprocess.check_output(['tox', '-l'])
-        assert output.decode('utf-8') == 'py27-django\n'
+
+        assert self.tox_envs() == set(['py27-django'])
 
     def test_factors(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -152,8 +155,8 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.4')
-        output = subprocess.check_output(['tox', '-l'])
-        assert output.decode('utf-8') == 'py34\npy34-docs\npy34-django\n'
+
+        assert self.tox_envs() == set(['py34', 'py34-docs', 'py34-django'])
 
     def test_django_factors(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -161,8 +164,8 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
-        output = subprocess.check_output(['tox', '-l'])
-        assert output.decode('utf-8') == 'py27-django\npy34-django\n'
+
+        assert self.tox_envs() == set(['py27-django', 'py34-django'])
 
     def test_non_python_factor(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -170,5 +173,5 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.4')
-        output = subprocess.check_output(['tox', '-l'])
-        assert output.decode('utf-8') == 'other\n'
+
+        assert self.tox_envs() == set(['other'])

--- a/test_tox_travis.py
+++ b/test_tox_travis.py
@@ -1,0 +1,174 @@
+import os
+import subprocess
+
+
+tox_ini = b"""
+[tox]
+envlist = py26, py27, py32, py33, py34, pypy, pypy3, docs
+"""
+
+tox_ini_override = tox_ini + b"""
+[tox:travis]
+2.7 = py27, docs
+"""
+
+tox_ini_factors = b"""
+[tox]
+envlist = py34, py34-docs, py34-django
+"""
+
+tox_ini_factors_override = tox_ini_factors + b"""
+[tox:travis]
+2.7 = py27-django
+"""
+
+tox_ini_django_factors = b"""
+[tox]
+envlist = py{27,34}-django, other
+
+[tox:travis]
+2.7 = django
+3.4 = other
+"""
+
+
+class TestToxTravis:
+    def test_not_travis(self, tmpdir):
+        os.chdir(str(tmpdir))
+        tmpdir.join('tox.ini').write(tox_ini)
+
+        output = subprocess.check_output(['tox', '-l'])
+        expected = '\n'.join([
+            'py26', 'py27',
+            'py32', 'py33', 'py34',
+            'pypy', 'pypy3',
+            'docs'
+        ]) + '\n'  # Expect a trailing newline
+        assert output.decode('utf-8') == expected
+
+    def test_travis_default_26(self, tmpdir, monkeypatch):
+        os.chdir(str(tmpdir))
+        tmpdir.join('tox.ini').write(tox_ini)
+
+        monkeypatch.setenv('TRAVIS', 'true')
+        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.6')
+        output = subprocess.check_output(['tox', '-l'])
+        assert output.decode('utf-8') == 'py26\n'
+
+    def test_travis_default_27(self, tmpdir, monkeypatch):
+        os.chdir(str(tmpdir))
+        tmpdir.join('tox.ini').write(tox_ini)
+
+        monkeypatch.setenv('TRAVIS', 'true')
+        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
+        output = subprocess.check_output(['tox', '-l'])
+        assert output.decode('utf-8') == 'py27\n'
+
+    def test_travis_default_32(self, tmpdir, monkeypatch):
+        os.chdir(str(tmpdir))
+        tmpdir.join('tox.ini').write(tox_ini)
+
+        monkeypatch.setenv('TRAVIS', 'true')
+        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.2')
+        output = subprocess.check_output(['tox', '-l'])
+        assert output.decode('utf-8') == 'py32\n'
+
+    def test_travis_default_33(self, tmpdir, monkeypatch):
+        os.chdir(str(tmpdir))
+        tmpdir.join('tox.ini').write(tox_ini)
+
+        monkeypatch.setenv('TRAVIS', 'true')
+        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.3')
+        output = subprocess.check_output(['tox', '-l'])
+        assert output.decode('utf-8') == 'py33\n'
+
+    def test_travis_default_34(self, tmpdir, monkeypatch):
+        os.chdir(str(tmpdir))
+        tmpdir.join('tox.ini').write(tox_ini)
+
+        monkeypatch.setenv('TRAVIS', 'true')
+        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.4')
+        output = subprocess.check_output(['tox', '-l'])
+        assert output.decode('utf-8') == 'py34\n'
+
+    def test_travis_default_pypy(self, tmpdir, monkeypatch):
+        os.chdir(str(tmpdir))
+        tmpdir.join('tox.ini').write(tox_ini)
+
+        monkeypatch.setenv('TRAVIS', 'true')
+        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', 'pypy')
+        output = subprocess.check_output(['tox', '-l'])
+        assert output.decode('utf-8') == 'pypy\n'
+
+    def test_travis_default_pypy3(self, tmpdir, monkeypatch):
+        os.chdir(str(tmpdir))
+        tmpdir.join('tox.ini').write(tox_ini)
+
+        monkeypatch.setenv('TRAVIS', 'true')
+        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', 'pypy3')
+        output = subprocess.check_output(['tox', '-l'])
+        assert output.decode('utf-8') == 'pypy3\n'
+
+    def test_travis_override(self, tmpdir, monkeypatch):
+        os.chdir(str(tmpdir))
+        tmpdir.join('tox.ini').write(tox_ini_override)
+
+        monkeypatch.setenv('TRAVIS', 'true')
+        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
+        output = subprocess.check_output(['tox', '-l'])
+        assert output.decode('utf-8') == 'py27\ndocs\n'
+
+    def test_respect_overridden_toxenv(self, tmpdir, monkeypatch):
+        os.chdir(str(tmpdir))
+        tmpdir.join('tox.ini').write(tox_ini)
+
+        monkeypatch.setenv('TRAVIS', 'true')
+        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
+        monkeypatch.setenv('TOXENV', 'py32')
+        output = subprocess.check_output(['tox', '-l'])
+        assert output.decode('utf-8') == 'py32\n'
+
+    def test_keep_if_no_match(self, tmpdir, monkeypatch):
+        os.chdir(str(tmpdir))
+        tmpdir.join('tox.ini').write(tox_ini_factors)
+
+        monkeypatch.setenv('TRAVIS', 'true')
+        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
+        output = subprocess.check_output(['tox', '-l'])
+        assert output.decode('utf-8') == 'py27\n'
+
+    def test_default_tox_ini_overrides(self, tmpdir, monkeypatch):
+        os.chdir(str(tmpdir))
+        tmpdir.join('tox.ini').write(tox_ini_factors_override)
+
+        monkeypatch.setenv('TRAVIS', 'true')
+        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
+        output = subprocess.check_output(['tox', '-l'])
+        assert output.decode('utf-8') == 'py27-django\n'
+
+    def test_factors(self, tmpdir, monkeypatch):
+        os.chdir(str(tmpdir))
+        tmpdir.join('tox.ini').write(tox_ini_factors)
+
+        monkeypatch.setenv('TRAVIS', 'true')
+        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.4')
+        output = subprocess.check_output(['tox', '-l'])
+        assert output.decode('utf-8') == 'py34\npy34-docs\npy34-django\n'
+
+    def test_django_factors(self, tmpdir, monkeypatch):
+        os.chdir(str(tmpdir))
+        tmpdir.join('tox.ini').write(tox_ini_django_factors)
+
+        monkeypatch.setenv('TRAVIS', 'true')
+        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
+        output = subprocess.check_output(['tox', '-l'])
+        assert output.decode('utf-8') == 'py27-django\npy34-django\n'
+
+    def test_non_python_factor(self, tmpdir, monkeypatch):
+        os.chdir(str(tmpdir))
+        tmpdir.join('tox.ini').write(tox_ini_django_factors)
+
+        monkeypatch.setenv('TRAVIS', 'true')
+        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.4')
+        output = subprocess.check_output(['tox', '-l'])
+        assert output.decode('utf-8') == 'other\n'

--- a/test_tox_travis.py
+++ b/test_tox_travis.py
@@ -34,18 +34,19 @@ envlist = py{27,34}-django, other
 
 class TestToxTravis:
     def tox_envs(self):
+        """Find the envs that tox sees."""
         output = subprocess.Popen(
             ['tox', '-l'], stdout=subprocess.PIPE).communicate()[0]
-        return set(output.decode('utf-8').strip().split())
+        return output.decode('utf-8').strip().split()
 
     def test_not_travis(self, tmpdir):
         os.chdir(str(tmpdir))
         tmpdir.join('tox.ini').write(tox_ini)
 
-        expected = set([
+        expected = [
             'py26', 'py27', 'py32', 'py33', 'py34',
             'pypy', 'pypy3', 'docs',
-        ])
+        ]
 
         assert self.tox_envs() == expected
 
@@ -56,7 +57,7 @@ class TestToxTravis:
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.6')
 
-        assert self.tox_envs() == set(['py26'])
+        assert self.tox_envs() == ['py26']
 
     def test_travis_default_27(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -65,7 +66,7 @@ class TestToxTravis:
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
 
-        assert self.tox_envs() == set(['py27'])
+        assert self.tox_envs() == ['py27']
 
     def test_travis_default_32(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -74,7 +75,7 @@ class TestToxTravis:
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.2')
 
-        assert self.tox_envs() == set(['py32'])
+        assert self.tox_envs() == ['py32']
 
     def test_travis_default_33(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -83,7 +84,7 @@ class TestToxTravis:
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.3')
 
-        assert self.tox_envs() == set(['py33'])
+        assert self.tox_envs() == ['py33']
 
     def test_travis_default_34(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -92,7 +93,7 @@ class TestToxTravis:
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.4')
 
-        assert self.tox_envs() == set(['py34'])
+        assert self.tox_envs() == ['py34']
 
     def test_travis_default_pypy(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -101,7 +102,7 @@ class TestToxTravis:
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', 'pypy')
 
-        assert self.tox_envs() == set(['pypy'])
+        assert self.tox_envs() == ['pypy']
 
     def test_travis_default_pypy3(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -110,7 +111,7 @@ class TestToxTravis:
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', 'pypy3')
 
-        assert self.tox_envs() == set(['pypy3'])
+        assert self.tox_envs() == ['pypy3']
 
     def test_travis_override(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -119,7 +120,7 @@ class TestToxTravis:
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
 
-        assert self.tox_envs() == set(['py27', 'docs'])
+        assert self.tox_envs() == ['py27', 'docs']
 
     def test_respect_overridden_toxenv(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -129,7 +130,7 @@ class TestToxTravis:
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
         monkeypatch.setenv('TOXENV', 'py32')
 
-        assert self.tox_envs() == set(['py32'])
+        assert self.tox_envs() == ['py32']
 
     def test_keep_if_no_match(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -138,7 +139,7 @@ class TestToxTravis:
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
 
-        assert self.tox_envs() == set(['py27'])
+        assert self.tox_envs() == ['py27']
 
     def test_default_tox_ini_overrides(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -147,7 +148,7 @@ class TestToxTravis:
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
 
-        assert self.tox_envs() == set(['py27-django'])
+        assert self.tox_envs() == ['py27-django']
 
     def test_factors(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -156,7 +157,7 @@ class TestToxTravis:
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.4')
 
-        assert self.tox_envs() == set(['py34', 'py34-docs', 'py34-django'])
+        assert self.tox_envs() == ['py34', 'py34-docs', 'py34-django']
 
     def test_django_factors(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -165,7 +166,7 @@ class TestToxTravis:
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
 
-        assert self.tox_envs() == set(['py27-django', 'py34-django'])
+        assert self.tox_envs() == ['py27-django', 'py34-django']
 
     def test_non_python_factor(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))
@@ -174,4 +175,4 @@ class TestToxTravis:
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.4')
 
-        assert self.tox_envs() == set(['other'])
+        assert self.tox_envs() == ['other']

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
-envlist = py26, py27, py32, py33, py34, pypy, pypy3, false
+envlist = py26, py27, py32, py33, py34, pypy, pypy3
 
 [testenv]
-commands = python -c 'import sys; sys.exit(0)'
-
-[testenv:false]
-commands = python -c 'import sys; sys.exit(1)'
+deps =
+    pytest
+commands = py.test

--- a/tox_travis.py
+++ b/tox_travis.py
@@ -2,6 +2,8 @@ import os
 import py
 import tox
 
+from tox.config import _split_env as split_env
+
 
 TOX_DEFAULTS = {
     '2.6': 'py26',
@@ -23,8 +25,38 @@ def tox_addoption(parser):
     version = os.environ.get('TRAVIS_PYTHON_VERSION')
 
     config = py.iniconfig.IniConfig('tox.ini')
-    section = config.sections.get('tox:travis', {})
-    envlist = section.get(version, TOX_DEFAULTS.get(version))
+    travis_section = config.sections.get('tox:travis', {})
+    tox_section = config.sections.get('tox', {})
 
-    if envlist:
-        os.environ.setdefault('TOXENV', envlist)
+    # Find the envs that tox knows about
+    envlist = split_env(tox_section.get('envlist', []))
+
+    # Find and expand the requested envs
+    envstr = travis_section.get(version, TOX_DEFAULTS.get(version))
+    desired_envlist = split_env(envstr)
+
+    matched = [
+        env for env in envlist if any(
+            env_matches(env, desired_env)
+            for desired_env in desired_envlist
+        )
+    ]
+
+    # If no envs match, just use the desired envstr directly
+    if not matched:
+        matched = [envstr]
+
+    os.environ.setdefault('TOXENV', ','.join(matched))
+
+
+def env_matches(env, desired_env):
+    """Determine if an env matches a desired env.
+
+    Rather than simply using the name of the env verbatim, take a
+    closer look to see if all the desired factors are fulfilled. If
+    the desired factors are fulfilled, but there are other factors,
+    it should still match the env.
+    """
+    desired_factors = desired_env.split('-')
+    env_factors = env.split('-')
+    return all(factor in env_factors for factor in desired_factors)


### PR DESCRIPTION
It would be most convenient if the default setup automatically ran all of the environments that match a particular version of Python. For instance, if we had the following `tox.ini`:

```ini
[tox]
envlist = py27-{django,flask,pyramid}, docs
```

In this case, we'd like the `py27-django`, `py27-flask`, and `py27-pyramid` envs to be run automatically, without additional configuration, though the `docs` env would be left out of the run in the default settings.

The right approach for this seemed to be to interpret the factors (the parts separated with `-`), and match accordingly. This extensible approach should make it easy to override as well, as just adding this new section to the `tox.ini` should be sufficient to get the docs running, and doesn't cause a whole bunch of duplication:

```ini
[tox:travis]
2.7 = py27, docs
```