### PR TITLE
Fix an Advanced Configuration section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,8 +42,8 @@ to run under which versions of Python:
     envlist = py{27,34}-django{17,18}, docs
 
     [tox:travis]
-    2.7 = py27
-    3.4 = py34, docs
+    2.7 = py27-django{17,18}
+    3.4 = py34-django{17,18}, docs
 
 This would run the Python 2.7 variants under 2.7,
 and the Python 3.4 variants and the ``docs`` env under 3.4.


### PR DESCRIPTION
Thanks for this great plugin. One thing I noticed that users need to speicfy '-django{17,18}' as well to run all variants. So README should be updated as my PR.

My working example: https://travis-ci.org/lambdalisue/django-permission/builds/95841648