### PR TITLE
Fix desired envs not matching declared envs that aren't in the envlist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
 /*.egg-info/
 /.tox/
+/.cache/
 /build/
 /dist/

--- a/test_tox_travis.py
+++ b/test_tox_travis.py
@@ -14,7 +14,7 @@ tox_ini_override = tox_ini + b"""
 
 tox_ini_factors = b"""
 [tox]
-envlist = py34, py34-docs, py34-django
+envlist = py34, py34-docs, py34-django, dontmatch-1
 """
 
 tox_ini_factors_override = tox_ini_factors + b"""
@@ -24,9 +24,15 @@ tox_ini_factors_override = tox_ini_factors + b"""
 
 tox_ini_factors_override_nonenvlist = tox_ini_factors + b"""
 [tox:travis]
-3.4 = py34, coveralls
+3.4 = py34, extra
 
-[testenv:coveralls]
+[testenv:extra-coveralls]
+basepython=python3.4
+
+[testenv:extra-flake8]
+basepython=python3.4
+
+[testenv:dontmatch-2]
 basepython=python3.4
 """
 
@@ -175,7 +181,7 @@ class TestToxTravis:
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.4')
 
         assert self.tox_envs() == ['py34', 'py34-docs', 'py34-django',
-                                   'coveralls']
+                                   'extra-coveralls', 'extra-flake8']
 
     def test_django_factors(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))

--- a/test_tox_travis.py
+++ b/test_tox_travis.py
@@ -22,6 +22,14 @@ tox_ini_factors_override = tox_ini_factors + b"""
 2.7 = py27-django
 """
 
+tox_ini_factors_override_nonenvlist = tox_ini_factors + b"""
+[tox:travis]
+3.4 = py34, coveralls
+
+[testenv:coveralls]
+basepython=python3.4
+"""
+
 tox_ini_django_factors = b"""
 [tox]
 envlist = py{27,34}-django, other
@@ -158,6 +166,16 @@ class TestToxTravis:
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.4')
 
         assert self.tox_envs() == ['py34', 'py34-docs', 'py34-django']
+
+    def test_match_and_keep(self, tmpdir, monkeypatch):
+        os.chdir(str(tmpdir))
+        tmpdir.join('tox.ini').write(tox_ini_factors_override_nonenvlist)
+
+        monkeypatch.setenv('TRAVIS', 'true')
+        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.4')
+
+        assert self.tox_envs() == ['py34', 'py34-docs', 'py34-django',
+                                   'coveralls']
 
     def test_django_factors(self, tmpdir, monkeypatch):
         os.chdir(str(tmpdir))

--- a/tox.ini
+++ b/tox.ini
@@ -4,4 +4,4 @@ envlist = py26, py27, py32, py33, py34, pypy, pypy3
 [testenv]
 deps =
     pytest
-commands = py.test
+commands = {posargs:py.test}

--- a/tox_travis.py
+++ b/tox_travis.py
@@ -30,6 +30,11 @@ def tox_addoption(parser):
 
     # Find the envs that tox knows about
     envlist = split_env(tox_section.get('envlist', []))
+    envlist_set = set(envlist)
+    envlist.extend(
+        s[8:] for s in sorted(config.sections, key=config.lineof)
+        if s.startswith('testenv:')
+        and s[8:] not in envlist_set)
 
     # Find and expand the requested envs
     envstr = travis_section.get(version, TOX_DEFAULTS.get(version))

--- a/tox_travis.py
+++ b/tox_travis.py
@@ -35,16 +35,20 @@ def tox_addoption(parser):
     envstr = travis_section.get(version, TOX_DEFAULTS.get(version))
     desired_envlist = split_env(envstr)
 
-    matched = [
-        env for env in envlist if any(
-            env_matches(env, desired_env)
-            for desired_env in desired_envlist
-        )
-    ]
+    matched = []
+    matchmakers = set()
+    for env in envlist:
+        match = False
+        for desired_env in desired_envlist:
+            if env_matches(env, desired_env):
+                match = True
+                matchmakers.add(desired_env)
+        if match:
+            matched.append(env)
 
-    # If no envs match, just use the desired envstr directly
-    if not matched:
-        matched = [envstr]
+    # Add desired envs which yielded no match with the envlist
+    matched.extend(env for env in desired_envlist
+                   if env not in matchmakers)
 
     os.environ.setdefault('TOXENV', ','.join(matched))
 


### PR DESCRIPTION
For instance, ``coveralls`` in the ``[tox:travis]`` section would get ignored because ``py34`` matches things in the envlist already.

```
[tox]
envlist = py34, py34-docs, py34-django

[tox:travis]
3.4 = py34, coveralls

[testenv:coveralls]
basepython=python3.4
```

If you can think of a better oneliner to explain it, more power to you :-)