### PR TITLE
Drop support for Python 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,9 @@ language: python
 python:
  - "2.6"
  - "2.7"
- - "3.2"
  - "3.3"
  - "3.4"
  - "3.5"
  - "pypy"
- - "pypy3"
 install: pip install .
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py32, py33, py34, pypy, pypy3
+envlist = py26, py27, py33, py34, pypy
 
 [testenv]
 deps =


### PR DESCRIPTION
The latest version of pip, version 8, does not support Python 3.2 any longer. This has manifested itself in failing builds on Travis CI. Since pip has decided it's reasonable to drop support for Python 3.2, it probably is for tox-travis as well.

PyPy3 still only support Python 3.2, so it is also dropped for now.