### PR TITLE
Generate default env instead of hard-coded lookup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,8 @@ python:
  - "pypy"
 install: pip install .
 script: tox
+branches:
+  only:
+    - master
+matrix:
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
  - "3.4"
  - "3.5"
  - "pypy"
+ - "nightly"
 install: pip install .
 script: tox
 branches:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,10 @@
+0.4 (TBD)
++++++++++
+
+* Generate default env from sys.version_info (#9)
+  - thanks to @jayvdb for the bug report
+
+
 0.3 (2016-01-26)
 ++++++++++++++++
 

--- a/test_tox_travis.py
+++ b/test_tox_travis.py
@@ -53,165 +53,97 @@ class TestToxTravis:
             ['tox', '-l'], stdout=subprocess.PIPE).communicate()[0]
         return output.decode('utf-8').strip().split()
 
-    def test_not_travis(self, tmpdir):
+    def configure(self, tmpdir, monkeypatch, tox_ini,
+                  version=None, major=None, minor=None):
         os.chdir(str(tmpdir))
         tmpdir.join('tox.ini').write(tox_ini)
 
+        if version:
+            sys_version = '{version},{major},{minor}'.format(
+                version=version, major=major, minor=minor)
+            travis_version = '{major}.{minor}'.format(
+                major=major, minor=minor)
+            if version == 'PyPy':
+                travis_version = 'pypy3' if major == 3 else 'pypy'
+
+            monkeypatch.setenv('TRAVIS', 'true')
+            monkeypatch.setenv('TRAVIS_PYTHON_VERSION', travis_version)
+            monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', sys_version)
+
+
+    def test_not_travis(self, tmpdir, monkeypatch):
+        self.configure(tmpdir, monkeypatch, tox_ini)
         expected = [
             'py26', 'py27', 'py32', 'py33', 'py34',
             'pypy', 'pypy3', 'docs',
         ]
-
         assert self.tox_envs() == expected
 
     def test_travis_default_26(self, tmpdir, monkeypatch):
-        os.chdir(str(tmpdir))
-        tmpdir.join('tox.ini').write(tox_ini)
-
-        monkeypatch.setenv('TRAVIS', 'true')
-        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.6')
-        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,2,6')
-
+        self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 2, 6)
         assert self.tox_envs() == ['py26']
 
     def test_travis_default_27(self, tmpdir, monkeypatch):
-        os.chdir(str(tmpdir))
-        tmpdir.join('tox.ini').write(tox_ini)
-
-        monkeypatch.setenv('TRAVIS', 'true')
-        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
-        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,2,7')
-
+        self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 2, 7)
         assert self.tox_envs() == ['py27']
 
     def test_travis_default_32(self, tmpdir, monkeypatch):
-        os.chdir(str(tmpdir))
-        tmpdir.join('tox.ini').write(tox_ini)
-
-        monkeypatch.setenv('TRAVIS', 'true')
-        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.2')
-        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,3,2')
-
+        self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 2)
         assert self.tox_envs() == ['py32']
 
     def test_travis_default_33(self, tmpdir, monkeypatch):
-        os.chdir(str(tmpdir))
-        tmpdir.join('tox.ini').write(tox_ini)
-
-        monkeypatch.setenv('TRAVIS', 'true')
-        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.3')
-        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,3,3')
-
+        self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 3)
         assert self.tox_envs() == ['py33']
 
     def test_travis_default_34(self, tmpdir, monkeypatch):
-        os.chdir(str(tmpdir))
-        tmpdir.join('tox.ini').write(tox_ini)
-
-        monkeypatch.setenv('TRAVIS', 'true')
-        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.4')
-        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,3,4')
-
+        self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 4)
         assert self.tox_envs() == ['py34']
 
     def test_travis_default_pypy(self, tmpdir, monkeypatch):
-        os.chdir(str(tmpdir))
-        tmpdir.join('tox.ini').write(tox_ini)
-
-        monkeypatch.setenv('TRAVIS', 'true')
-        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', 'pypy')
-        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'PyPy,2,7')
-
+        self.configure(tmpdir, monkeypatch, tox_ini, 'PyPy', 2, 7)
         assert self.tox_envs() == ['pypy']
 
     def test_travis_default_pypy3(self, tmpdir, monkeypatch):
-        os.chdir(str(tmpdir))
-        tmpdir.join('tox.ini').write(tox_ini)
-
-        monkeypatch.setenv('TRAVIS', 'true')
-        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', 'pypy3')
-        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'PyPy,3,2')
-
+        self.configure(tmpdir, monkeypatch, tox_ini, 'PyPy', 3, 2)
         assert self.tox_envs() == ['pypy3']
 
     def test_travis_override(self, tmpdir, monkeypatch):
-        os.chdir(str(tmpdir))
-        tmpdir.join('tox.ini').write(tox_ini_override)
-
-        monkeypatch.setenv('TRAVIS', 'true')
-        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
-        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,2,7')
-
+        tox_ini = tox_ini_override
+        self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 2, 7)
         assert self.tox_envs() == ['py27', 'docs']
 
     def test_respect_overridden_toxenv(self, tmpdir, monkeypatch):
-        os.chdir(str(tmpdir))
-        tmpdir.join('tox.ini').write(tox_ini)
-
-        monkeypatch.setenv('TRAVIS', 'true')
-        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
-        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,2,7')
+        self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 2, 7)
         monkeypatch.setenv('TOXENV', 'py32')
-
         assert self.tox_envs() == ['py32']
 
     def test_keep_if_no_match(self, tmpdir, monkeypatch):
-        os.chdir(str(tmpdir))
-        tmpdir.join('tox.ini').write(tox_ini_factors)
-
-        monkeypatch.setenv('TRAVIS', 'true')
-        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
-        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,2,7')
-
+        tox_ini = tox_ini_factors
+        self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 2, 7)
         assert self.tox_envs() == ['py27']
 
     def test_default_tox_ini_overrides(self, tmpdir, monkeypatch):
-        os.chdir(str(tmpdir))
-        tmpdir.join('tox.ini').write(tox_ini_factors_override)
-
-        monkeypatch.setenv('TRAVIS', 'true')
-        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
-        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,2,7')
-
+        tox_ini = tox_ini_factors_override
+        self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 2, 7)
         assert self.tox_envs() == ['py27-django']
 
     def test_factors(self, tmpdir, monkeypatch):
-        os.chdir(str(tmpdir))
-        tmpdir.join('tox.ini').write(tox_ini_factors)
-
-        monkeypatch.setenv('TRAVIS', 'true')
-        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.4')
-        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,3,4')
-
+        tox_ini = tox_ini_factors
+        self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 4)
         assert self.tox_envs() == ['py34', 'py34-docs', 'py34-django']
 
     def test_match_and_keep(self, tmpdir, monkeypatch):
-        os.chdir(str(tmpdir))
-        tmpdir.join('tox.ini').write(tox_ini_factors_override_nonenvlist)
-
-        monkeypatch.setenv('TRAVIS', 'true')
-        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.4')
-        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,3,4')
-
+        tox_ini = tox_ini_factors_override_nonenvlist
+        self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 4)
         assert self.tox_envs() == ['py34', 'py34-docs', 'py34-django',
                                    'extra-coveralls', 'extra-flake8']
 
     def test_django_factors(self, tmpdir, monkeypatch):
-        os.chdir(str(tmpdir))
-        tmpdir.join('tox.ini').write(tox_ini_django_factors)
-
-        monkeypatch.setenv('TRAVIS', 'true')
-        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
-        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,2,7')
-
+        tox_ini = tox_ini_django_factors
+        self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 2, 7)
         assert self.tox_envs() == ['py27-django', 'py34-django']
 
     def test_non_python_factor(self, tmpdir, monkeypatch):
-        os.chdir(str(tmpdir))
-        tmpdir.join('tox.ini').write(tox_ini_django_factors)
-
-        monkeypatch.setenv('TRAVIS', 'true')
-        monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.4')
-        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,3,4')
-
+        tox_ini = tox_ini_django_factors
+        self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 4)
         assert self.tox_envs() == ['other']

--- a/test_tox_travis.py
+++ b/test_tox_travis.py
@@ -70,6 +70,7 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.6')
+        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,2,6')
 
         assert self.tox_envs() == ['py26']
 
@@ -79,6 +80,7 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
+        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,2,7')
 
         assert self.tox_envs() == ['py27']
 
@@ -88,6 +90,7 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.2')
+        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,3,2')
 
         assert self.tox_envs() == ['py32']
 
@@ -97,6 +100,7 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.3')
+        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,3,3')
 
         assert self.tox_envs() == ['py33']
 
@@ -106,6 +110,7 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.4')
+        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,3,4')
 
         assert self.tox_envs() == ['py34']
 
@@ -115,6 +120,7 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', 'pypy')
+        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'PyPy,2,7')
 
         assert self.tox_envs() == ['pypy']
 
@@ -124,6 +130,7 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', 'pypy3')
+        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'PyPy,3,2')
 
         assert self.tox_envs() == ['pypy3']
 
@@ -133,6 +140,7 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
+        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,2,7')
 
         assert self.tox_envs() == ['py27', 'docs']
 
@@ -142,6 +150,7 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
+        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,2,7')
         monkeypatch.setenv('TOXENV', 'py32')
 
         assert self.tox_envs() == ['py32']
@@ -152,6 +161,7 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
+        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,2,7')
 
         assert self.tox_envs() == ['py27']
 
@@ -161,6 +171,7 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
+        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,2,7')
 
         assert self.tox_envs() == ['py27-django']
 
@@ -170,6 +181,7 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.4')
+        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,3,4')
 
         assert self.tox_envs() == ['py34', 'py34-docs', 'py34-django']
 
@@ -179,6 +191,7 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.4')
+        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,3,4')
 
         assert self.tox_envs() == ['py34', 'py34-docs', 'py34-django',
                                    'extra-coveralls', 'extra-flake8']
@@ -189,6 +202,7 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '2.7')
+        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,2,7')
 
         assert self.tox_envs() == ['py27-django', 'py34-django']
 
@@ -198,5 +212,6 @@ class TestToxTravis:
 
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PYTHON_VERSION', '3.4')
+        monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', 'CPython,3,4')
 
         assert self.tox_envs() == ['other']

--- a/test_tox_travis.py
+++ b/test_tox_travis.py
@@ -79,6 +79,13 @@ class TestToxTravis:
         ]
         assert self.tox_envs() == expected
 
+    def test_any_default(self, tmpdir, monkeypatch):
+        self.configure(tmpdir, monkeypatch, tox_ini)
+        monkeypatch.setenv('TRAVIS', 'true')
+        tox_envs = self.tox_envs()
+        assert len(tox_envs) == 1
+        assert tox_envs[0].startswith('py')
+
     def test_travis_default_26(self, tmpdir, monkeypatch):
         self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 2, 6)
         assert self.tox_envs() == ['py26']

--- a/tox_travis.py
+++ b/tox_travis.py
@@ -45,10 +45,24 @@ def get_declared_envs(config):
     return envlist + [env for env in section_envs if env not in envlist]
 
 
+def get_version_info():
+    """Get version info from the sys module.
+
+    Override from environment for testing.
+    """
+    overrides = os.environ.get('__TOX_TRAVIS_SYS_VERSION')
+    if overrides:
+        version, major, minor = overrides.split(',')[:3]
+        major, minor = int(major), int(minor)
+    else:
+        version, (major, minor) = sys.version, sys.version_info[:2]
+    return version, major, minor
+
+
 def guess_python_env():
     """Guess the default python env to use."""
-    major, minor = sys.version_info[:2]
-    if 'PyPy' in sys.version:
+    version, major, minor = get_version_info()
+    if 'PyPy' in version:
         return 'pypy3' if major == 3 else 'pypy'
     return 'py{major}{minor}'.format(major=major, minor=minor)
 


### PR DESCRIPTION
Fixes #9
Closes #10

The improved error handling of #10 should not be needed with this approach, and any new python version should "just work", assuming that the generation of tox envs continues following the current pattern.