### PR TITLE
Parse TRAVIS_PYTHON_VERSION to get python version

### DIFF
--- a/test_tox_travis.py
+++ b/test_tox_travis.py
@@ -148,6 +148,12 @@ class TestToxTravis:
         self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 2, 7, '3.5')
         assert self.tox_envs() == ['py35']
 
+    def test_travis_nightly(self, tmpdir, monkeypatch):
+        """When nightly is specified, it should use sys.version_info."""
+        self.configure(tmpdir, monkeypatch, tox_ini,
+                       'CPython', 3, 5, 'nightly')
+        assert self.tox_envs() == ['py35']
+
     def test_travis_override(self, tmpdir, monkeypatch):
         tox_ini = tox_ini_override
         self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 2, 7)

--- a/tox_travis.py
+++ b/tox_travis.py
@@ -72,22 +72,19 @@ def get_default_envlist(version):
     """Parse a default tox env based on the version.
 
     The version comes from the ``TRAVIS_PYTHON_VERSION`` environment
-    variable. If that isn't set, then use sys.version_info to come
-    up with a reasonable default.
+    variable. If that isn't set or is invalid, then use
+    sys.version_info to come up with a reasonable default.
     """
-    # If version isn't set, then guess from sys.version_info
-    if not version:
-        return guess_python_env()
+    if version in ['pypy', 'pypy3']:
+        return version
 
-    # Assume single digit versions
-    match = re.match(r'^(\d)\.(\d)$', version)
+    # Assume single digit major and minor versions
+    match = re.match(r'^(\d)\.(\d)(?:\.\d+)?$', version or '')
     if match:
         major, minor = match.groups()
         return 'py{major}{minor}'.format(major=major, minor=minor)
 
-    # Use the ``TRAVIS_PYTHON_VERSION`` verbatim. This works for
-    # at least pypy and pypy3.
-    return version
+    return guess_python_env()
 
 
 def get_desired_envs(config, version):


### PR DESCRIPTION
Using sys.version_info is a good fallback, but it doesn't allow TRAVIS_PYTHON_VERSION to be set explicitly in scenarios where Travis doesn't deal with Python versions, such as on multi-os builds under osx instead of linux.

Recent comments on #4 suggest support for multi-os builds, but that support is very limited currently. This should allow manually set ``TRAVIS_PYTHON_VERSION`` to behave identically to using the ``python`` configuration for versions.

References #4