### PR TITLE
Support PyPy3 v5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,25 @@ python:
  - "3.4"
  - "3.5"
  - "pypy"
+ - "pypy3"
+ - "pypy3.3-5.2-alpha1"
  - "nightly"
-install: pip install .
-script: tox
+
+before_install:
+ # Save the setuptools version
+ - ORIG_SETUPTOOLS_VERSION=`python -c "import setuptools; print('%s' % setuptools.__version__)"`
+ - echo setuptools $ORIG_SETUPTOOLS_VERSION
+install:
+ # A recent setuptools is needed to parse setup.py to create the wheel
+ - pip install --upgrade setuptools wheel
+ - python setup.py bdist_wheel
+ # Reset to original setuptools to confirm the wheel can be installed on
+ # Travis without any extra installation steps
+ - pip install --upgrade setuptools==$ORIG_SETUPTOOLS_VERSION
+ - pip install ./dist/tox_travis-*.whl
+script:
+ - tox --installpkg ./dist/tox_travis-*.whl
+
 branches:
   only:
     - master

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     install_requires=['tox>=2.0'],
     extras_require={
         ':python_version=="3.2"': ['virtualenv<14'],
+        ':platform_python_implementation=="PyPy" and python_version=="3.3"': ['virtualenv>=15.0.2'],
     },
     classifiers=[
         'Programming Language :: Python',

--- a/src/tox_travis.py
+++ b/src/tox_travis.py
@@ -5,6 +5,7 @@ import py
 import tox
 
 from tox.config import _split_env as split_env
+from tox.config import default_factors
 
 
 @tox.hookimpl
@@ -23,6 +24,14 @@ def tox_addoption(parser):
 
     matched = match_envs(declared_envs, desired_envs)
     os.environ.setdefault('TOXENV', ','.join(matched))
+
+    # Travis virtualenv do not provide `pypy3`, which tox tries to execute.
+    # This doesnt affect Travis python version `pypy3`, as the pyenv pypy3
+    # is in the PATH.
+    # https://github.com/travis-ci/travis-ci/issues/6304
+    # Force use of the virtualenv `python`.
+    if version and version.startswith('pypy3.3-5.2-'):
+        default_factors['pypy3'] = 'python'
 
 
 def get_declared_envs(config):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py32, py33, py34, pypy
+envlist = py26, py27, py32, py33, py34, pypy, pypy3
 
 [testenv]
 deps =


### PR DESCRIPTION
PyPy has started releasing alpha releases of PyPy3 v5.2, and Travis now supports `python: pypy3.3-5.2-alpha1`.

PyPy3 v5.2 depends on virtualenv>=15.0.2, whereas Travis installs 12.0.6. Only force the use of virtualenv>=15.0.2 on PyPy3 v5.2, so that existing users of tox-travis are not impacted. This is complicated by Travis providing setuptools 12.0.5, which does not support `platform_python_implementation=="PyPy"` as an environment marker, and fails to install tox-travis from a source tarball.  However tox-travis provides a universal wheel, which supports that environment marker, and Travis pip 6.0.7 can install it.

This change breaks any use of tox-travis with old setuptools. As tox-travis uses tox to install and test the package, either we use `skipdist=True` or tell tox to use a wheel to install tox-travis, thereby avoiding setuptools in tox.

Also, fiddle with tox internals so that it attempts to run `python` for the Travis versions `pypy3.3-5.2-*`.

Fixes #22