### PR TITLE
Support PyPy3 v5.2 with setuptools hackery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,18 @@ python:
  - "3.4"
  - "3.5"
  - "pypy"
+ - "pypy3"
+ - "pypy3.3-5.2-alpha1"
  - "nightly"
-install: pip install .
-script: tox
-branches:
-  only:
-    - master
-matrix:
-  fast_finish: true
+
+before_install:
+ # Show the current setuptools version
+ - ORIG_SETUPTOOLS_VERSION=`python -c "import setuptools; print('%s' % setuptools.__version__)"`
+ - echo setuptools $ORIG_SETUPTOOLS_VERSION
+install:
+ - pip install wheel
+ - python setup.py install bdist_wheel
+ - pip install ./dist/tox_travis-*.whl
+script:
+ - tox
+ - tox --installpkg ./dist/tox_travis-*.whl

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,56 @@
-from setuptools import setup
+import sys
+
+from setuptools import setup, __version__ as setuptools_version
+from pkg_resources import parse_version
+
+import pkg_resources
+
+try:
+    import _markerlib.markers
+except ImportError:
+    _markerlib = None
+
+
+# _markerlib.default_environment() obtains its data from _VARS
+# and wraps it in another dict, but _markerlib_evaluate writes
+# to the dict while it is iterating the keys, causing an error
+# on Python 3 only.
+# Replace _markerlib.default_environment to return a custom dict
+# that has all the necessary markers, and ignores any writes.
+
+class Python3MarkerDict(dict):
+
+    def __setitem__(self, key, value):
+        pass
+
+    def pop(self, i=-1):
+        return self[i]
+
+
+if _markerlib and sys.version_info[0] == 3:
+    env = _markerlib.markers._VARS
+    for key in list(env.keys()):
+        new_key = key.replace('.', '_')
+        if new_key != key:
+            env[new_key] = env[key]
+
+    _markerlib.markers._VARS = Python3MarkerDict(env)
+
+    def default_environment():
+        return _markerlib.markers._VARS
+
+    _markerlib.default_environment = default_environment
+
+# Avoid the very buggy pkg_resources.parser, which doesnt consistently
+# recognise the markers needed by this setup.py
+# Change this to setuptools 20.10.0 to support all markers.
+if pkg_resources:
+    if parse_version(setuptools_version) < parse_version('20.10.0'):
+        MarkerEvaluation = pkg_resources.MarkerEvaluation
+
+        del pkg_resources.parser
+        pkg_resources.evaluate_marker = MarkerEvaluation._markerlib_evaluate
+        MarkerEvaluation.evaluate_marker = MarkerEvaluation._markerlib_evaluate
 
 
 def fread(fn):
@@ -21,6 +73,7 @@ setup(
     install_requires=['tox>=2.0'],
     extras_require={
         ':python_version=="3.2"': ['virtualenv<14'],
+        ':platform_python_implementation=="PyPy" and python_version=="3.3"': ['virtualenv>=15.0.2'],
     },
     classifiers=[
         'Programming Language :: Python',

--- a/src/tox_travis.py
+++ b/src/tox_travis.py
@@ -5,6 +5,10 @@ import py
 import tox
 
 from tox.config import _split_env as split_env
+try:
+    from tox.config import default_factors
+except ImportError:
+    default_factors = None
 
 
 @tox.hookimpl
@@ -23,6 +27,14 @@ def tox_addoption(parser):
 
     matched = match_envs(declared_envs, desired_envs)
     os.environ.setdefault('TOXENV', ','.join(matched))
+
+    # Travis virtualenv do not provide `pypy3`, which tox tries to execute.
+    # This doesnt affect Travis python version `pypy3`, as the pyenv pypy3
+    # is in the PATH.
+    # https://github.com/travis-ci/travis-ci/issues/6304
+    # Force use of the virtualenv `python`.
+    if version and default_factors and version.startswith('pypy3.3-5.2-'):
+        default_factors['pypy3'] = 'python'
 
 
 def get_declared_envs(config):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py32, py33, py34, pypy
+envlist = py26, py27, py32, py33, py34, pypy, pypy3
 
 [testenv]
 deps =


### PR DESCRIPTION
PyPy has started releasing alpha releases of PyPy3 v5.2,
and Travis now supports `python: pypy3.3-5.2-alpha1`.

PyPy3 v5.2 depends on virtualenv>=15.0.2, whereas Travis installs 12.0.6.
Only force the use of virtualenv>=15.0.2 on PyPy3 v5.2, so that existing
users of tox-travis are not impacted.
This is complicated by Travis providing setuptools 12.0.5,
which does not support `platform_python_implementation=="PyPy"`
as an environment marker.  Prior to setuptools 20.10.0 there is patchy
support for environment markers, and setup.py fails while parsing them.

To avoid breakage if someone is installing tox-travis using an older
setuptools, setup.py patches _markerlib and pkg_resources to do the
correct environment marker matching.

However the typical Travis-CI usage is via `pip install tox-travis`.
tox-travis provides a universal wheel, which supports environment markers,
Travis pip 6.0.7 can install this universal wheel without using setuptools.

Also, fiddle with tox internals so that it attempts to
run `python` for the Travis versions `pypy3.3-5.2-*`.