### PR TITLE
Fix regression in Python: pypy3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     },
     install_requires=['tox>=2.0'],
     extras_require={
-        ':python_version=="3.2"': ['virtualenv<14'],
+        ':platform_python_implementation=="CPython" and python_version=="3.2"': ['virtualenv<14'],
         ':platform_python_implementation=="PyPy" and python_version=="3.3"': ['virtualenv>=15.0.2'],
     },
     classifiers=[


### PR DESCRIPTION
Only CPython 3.2 needs virtualenv<14, and PyPy3 2.4 breaks
due to pip version resolution bug when `pip install tox tox-travis`
is used.

Fixes regression in #26 