### PR TITLE
Python 3.2 requires pytest<3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
  - "pypy"
  - "pypy3"
  - "pypy3.3-5.2-alpha1"
- - "nightly"
+ - "3.6-dev"
 
 before_install:
  # Show the current setuptools version

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     },
     install_requires=['tox>=2.0'],
     extras_require={
-        ':python_version=="3.2"': ['virtualenv<14'],
+        ':python_version=="3.2"': ['virtualenv<14', 'pytest<3'],
         ':platform_python_implementation=="PyPy" and python_version=="3.3"': ['virtualenv>=15.0.2'],
     },
     classifiers=[


### PR DESCRIPTION
pytest 3.0 included Python syntax only available on Python 3.3

Also update Travis 'nightly' to be '3.6-dev',
as nightly is now Python 3.7 which isnt supported
by the latest released version of tox.

Fixes #31
Fixes #32