### PR TITLE
Support alternative Travis factors

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,14 @@
+0.7 (TBD)
++++++++++
+
+* Deprecate the ``[tox:travis]`` section in favor of
+  the ``python`` key to the new ``[travis]`` section.
+* Allow specifying envs by other Travis factors.
+  Includes ``os``, ``language``, and ``python``.
+* Allow specifying envs for environment variables,
+  in a new ``[travis:env]`` section.
+* Special thanks to @rpkibly for driving this work (#34)
+
 0.6 (2016-10-13)
 ++++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,23 @@
 * Allow specifying envs for environment variables,
   in a new ``[travis:env]`` section.
 * Special thanks to @rpkibly for driving this work (#34)
+* Backward incompatible changes:
+
+  * If *any* declared tox envs match the envs matched from factors,
+    no additional envs will be included automatically.
+    For example, if ``envlist`` is ``docs``,
+    and the configuration for python 3.4 is ``py34, docs``,
+    it previously would have run both the declared ``docs`` env,
+    as well as the undeclared ``py34`` env,
+    while now it will only run the declared ``docs`` env.
+    This may result in *fewer* envs running than expected,
+    but in edge cases that were believed to be unlikely.
+  * Previously, if no Python version was given in the environment,
+    it would automatically choose an appropriate env
+    based on the Python version running.
+    Now if no Python version is given in the environment
+    no env is determined by default,
+    which may result in *more* envs running in a job than expected.
 
 0.6 (2016-10-13)
 ++++++++++++++++

--- a/README.rst
+++ b/README.rst
@@ -52,9 +52,10 @@ to run under which versions of Python:
     [tox]
     envlist = py{27,34}-django{17,18}, docs
 
-    [tox:travis]
-    2.7 = py27
-    3.4 = py34, docs
+    [travis]
+    python =
+      2.7: py27
+      3.4: py34, docs
 
 This would run the Python 2.7 variants under 2.7,
 and the Python 3.4 variants and the ``docs`` env under 3.4.
@@ -63,3 +64,77 @@ Note that Travis won't run all the envs simultaneously,
 because it's build matrix is only aware of the Python versions.
 Only one Travis build will be run per Python version,
 unless other settings are specified in the Travis build matrix.
+
+If you are using multiple Travis factors,
+then you can use those factors to decide what will run.
+For example, see the following ``.travis.yml`` and ``tox.ini``:
+
+.. code-block::
+
+    sudo: false
+    language: python
+    python:
+      - "2.7"
+      - "3.4"
+    env:
+      - DJANGO="1.7"
+      - DJANGO="1.8"
+    include:
+      - os: osx
+        language: generic
+    install: pip install tox-travis
+    script: tox
+
+
+.. code-block:: ini
+
+    [tox]
+    envlist py{27,34}-django{17,18}, docs
+
+    [travis]
+    os =
+      linux: py{27,34}-django{17,18}, docs
+      osx: py{27,34}-django{17,18}
+    python =
+      3.4: py34, docs
+
+    [travis:env]
+    DJANGO =
+      1.7: django17
+      1.8: django18, docs
+
+Travis will run 5 different jobs,
+which will each run jobs as specified by the factors given.
+
+* os: linux (default), language: python, python: 2.7, env: DJANGO=1.7
+
+  This will run the env ``py27-django17``,
+  because ``py27`` is the default,
+  and ``django17`` is specified.
+
+* os: linux (default), language: python, python: 3.4, env: DJANGO=1.7
+
+  This will run the env ``py34-django17``,
+  but not ``docs``,
+  because ``docs`` is not included in the DJANGO 1.7 configuration.
+
+* os: linux (default), language: python, python: 2.7, env: DJANGO=1.8
+
+  This will run the env ``py27-django18``,
+  because ``py34`` is the default.
+  ``docs`` is not run,
+  because Python 2.7 doesn't include ``docs``
+  in the defaults that are not overridden.
+
+* os: linux (default), language: python, python: 3.4, env: DJANGO=1.8
+
+  This will run the envs ``py34-django18`` and ``docs``,
+  because all specified factors match,
+  and ``docs`` is present in all related factors.
+
+* os: osx, language: generic
+
+  This will run envs ``py27-django17``, ``py34-django17``,
+  ``py27-django18``, and ``py34-django18``,
+  because the ``os`` factor is present,
+  and limits it to just those envs.

--- a/src/tox_travis.py
+++ b/src/tox_travis.py
@@ -120,7 +120,36 @@ def get_default_envlist(version):
 
 
 def get_desired_factors(config):
-    """Get the list of desired envs per declared factor."""
+    """Get the list of desired envs per declared factor.
+
+    Look at all the accepted configuration locations, and give a list
+    of envlists, one for each Travis factor found.
+
+    Look in the ``[travis]`` section for the known Travis factors,
+    which are backed by environment variable checking behind the
+    scenes, but provide a cleaner interface.
+
+    Also look for the ``[tox:travis]`` section, which is deprecated,
+    and treat it as an additional ``python`` key from the ``[travis]``
+    section.
+
+    Finally, look for factors based directly on environment variables,
+    listed in the ``[travis:env]`` section. Configuration found in the
+    ``[travis]`` and ``[tox:travis]`` sections are converted to this
+    form under the hood, and are considered in the same way.
+
+    Special consideration is given to the ``python`` factor. If this
+    factor is set in the environment, then an appropriate configuration
+    will be provided automatically if no manual configuration is
+    provided.
+
+    To allow for the most flexible processing, the envlists provided
+    by each factor are not combined after they are selected, but
+    instead returned as a list of envlists, and expected to be
+    combined as and when appropriate by the caller. This allows for
+    special handling based on the number of factors that were found
+    to apply to this environment.
+    """
     # Find configuration based on known travis factors
     travis_section = config.sections.get('travis', {})
     found_factors = [

--- a/src/tox_travis.py
+++ b/src/tox_travis.py
@@ -121,6 +121,7 @@ def get_default_envlist(version):
 
 def get_desired_factors(config):
     """Get the list of desired envs per declared factor."""
+    # Find configuration based on known travis factors
     travis_section = config.sections.get('travis', {})
     found_factors = [
         (factor, parse_dict(travis_section[factor]))
@@ -128,6 +129,7 @@ def get_desired_factors(config):
         if factor in travis_section
     ]
 
+    # Backward compatibility with the old tox:travis section
     if 'tox:travis' in config.sections:
         print('The [tox:travis] section is deprecated in favor of'
               ' the "python" key of the [travis] section.', file=sys.stderr)
@@ -155,6 +157,7 @@ def get_desired_factors(config):
         for name, value in config.sections.get('travis:env', {}).items()
     ]
 
+    # Choose the correct envlists based on the factor values
     return [
         split_env(mapping[os.environ[name]])
         for name, mapping in env_factors

--- a/src/tox_travis.py
+++ b/src/tox_travis.py
@@ -13,6 +13,9 @@ except ImportError:
     default_factors = None
 
 
+LEGACY_WARN = "[tox:travis] is a legacy section and should not be used with [%s]."
+
+
 @tox.hookimpl
 def tox_addoption(parser):
     if 'TRAVIS' not in os.environ:
@@ -110,6 +113,9 @@ def _legacy_get_desired_envs(config, version):
 def get_desired_envs(config, version):
     """Get the expanded list of desired envs."""
     if 'tox:travis' in config.sections:
+        for section in config.sections:
+            assert not section.startswith('travis'), \
+                LEGACY_WARN % section
         return _legacy_get_desired_envs(config, version)
 
     # Parse the travis section

--- a/src/tox_travis.py
+++ b/src/tox_travis.py
@@ -4,6 +4,8 @@ import re
 import py
 import tox
 
+from itertools import product
+
 from tox.config import _split_env as split_env
 try:
     from tox.config import default_factors
@@ -161,6 +163,18 @@ def parse_dict(value):
         (key.strip(), split_env(value))
         for key, value in kv_pairs
     )
+
+
+def reduce_factors(factors):
+    """Reduce sets of factors into a single list of envs.
+
+        >>> reduce_factors([['py27', 'py35'], ['django110']])
+        ['py27-django110', 'py35-django110']
+
+    """
+    envs = product(*factors)
+    envs = ['-'.join(env) for env in envs]
+    return envs
 
 
 def match_envs(declared_envs, desired_envs):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,40 @@
+from tox_travis import parse_dict
+
+
+class TestParseDict:
+
+    def test_simple(self):
+        value = """
+        1.9: django19
+        1.10: django110
+        """
+        expected = {
+            '1.9': ['django19'],
+            '1.10': ['django110'],
+        }
+
+        assert parse_dict(value) == expected
+
+    def test_comma_separated_list(self):
+        value = """
+        2.7: py27, docs
+        3.5: py35
+        """
+        expected = {
+            '2.7': ['py27', 'docs'],
+            '3.5': ['py35'],
+        }
+
+        assert parse_dict(value) == expected
+
+    def test_brace_expansion(self):
+        value = """
+        2.7: py27, docs
+        3: py{35,36}
+        """
+        expected = {
+            '2.7': ['py27', 'docs'],
+            '3': ['py35', 'py36'],
+        }
+
+        assert parse_dict(value) == expected

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,4 @@
-from tox_travis import parse_dict, reduce_factors
+from tox_travis import parse_dict
 
 
 class TestParseDict:
@@ -9,8 +9,8 @@ class TestParseDict:
         1.10: django110
         """
         expected = {
-            '1.9': ['django19'],
-            '1.10': ['django110'],
+            '1.9': 'django19',
+            '1.10': 'django110',
         }
 
         assert parse_dict(value) == expected
@@ -21,49 +21,20 @@ class TestParseDict:
         3.5: py35
         """
         expected = {
-            '2.7': ['py27', 'docs'],
-            '3.5': ['py35'],
+            '2.7': 'py27, docs',
+            '3.5': 'py35',
         }
 
         assert parse_dict(value) == expected
 
-    def test_brace_expansion(self):
+    def test_brace_no_expansion(self):
         value = """
         2.7: py27, docs
-        3: py{35,36}
+        3.5: py{35,36}
         """
         expected = {
-            '2.7': ['py27', 'docs'],
-            '3': ['py35', 'py36'],
+            '2.7': 'py27, docs',
+            '3.5': 'py{35,36}',
         }
 
         assert parse_dict(value) == expected
-
-
-class TestReduceFactors:
-
-    def test_simple(self):
-        factors = [
-            ['py35'],
-            ['django110'],
-        ]
-        expected = [
-            'py35-django110',
-        ]
-
-        assert reduce_factors(factors) == expected
-
-    def test_multiple(self):
-        factors = [
-            ['py27', 'py35'],
-            ['django19'],
-            ['drf33', 'drf34'],
-        ]
-        expected = [
-            'py27-django19-drf33',
-            'py27-django19-drf34',
-            'py35-django19-drf33',
-            'py35-django19-drf34',
-        ]
-
-        assert reduce_factors(factors) == expected

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,4 @@
-from tox_travis import parse_dict
+from tox_travis import parse_dict, reduce_factors
 
 
 class TestParseDict:
@@ -38,3 +38,32 @@ class TestParseDict:
         }
 
         assert parse_dict(value) == expected
+
+
+class TestReduceFactors:
+
+    def test_simple(self):
+        factors = [
+            ['py35'],
+            ['django110'],
+        ]
+        expected = [
+            'py35-django110',
+        ]
+
+        assert reduce_factors(factors) == expected
+
+    def test_multiple(self):
+        factors = [
+            ['py27', 'py35'],
+            ['django19'],
+            ['drf33', 'drf34'],
+        ]
+        expected = [
+            'py27-django19-drf33',
+            'py27-django19-drf34',
+            'py35-django19-drf33',
+            'py35-django19-drf34',
+        ]
+
+        assert reduce_factors(factors) == expected

--- a/tests/test_tox_travis.py
+++ b/tests/test_tox_travis.py
@@ -96,7 +96,7 @@ class TestToxTravis:
         proc = subprocess.Popen(
             ['tox', '-l'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = proc.communicate()
-        return 0, stdout.decode('utf-8'), stderr.decode('utf-8')
+        return proc.returncode, stdout.decode('utf-8'), stderr.decode('utf-8')
 
     def configure(self, tmpdir, monkeypatch, tox_ini,
                   version=None, major=None, minor=None,

--- a/tests/test_tox_travis.py
+++ b/tests/test_tox_travis.py
@@ -49,12 +49,13 @@ envlist = py{27,34}-django, other
 
 tox_ini_travis_factors = b"""
 [tox]
-envlist = py{27,35}, docs
+envlist = py{27,34,35}, docs
 
 [travis]
+language =
+    generic: py{27,35}, docs
 python =
     2.7: py27, docs
-
 os =
     osx: py{27,35}, docs
 """
@@ -86,21 +87,25 @@ DJANGO =
 class TestToxTravis:
     def tox_envs(self):
         """Find the envs that tox sees."""
+        returncode, stdout, stderr = self.tox_envs_raw()
+        assert returncode == 0, stderr
+        return [env for env in stdout.strip().split('\n')]
+
+    def tox_envs_raw(self):
+        """Return the raw output of finding what tox sees."""
         proc = subprocess.Popen(
             ['tox', '-l'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = proc.communicate()
-
-        assert proc.returncode == 0, stderr.decode('utf-8')
-        return stdout.decode('utf-8').strip().split()
+        return 0, stdout.decode('utf-8'), stderr.decode('utf-8')
 
     def configure(self, tmpdir, monkeypatch, tox_ini,
                   version=None, major=None, minor=None,
                   travis_version=None, travis_os=None,
-                  env=None):
+                  travis_language=None, env=None):
         os.chdir(str(tmpdir))
         tmpdir.join('tox.ini').write(tox_ini)
 
-        if version or travis_version or travis_os:
+        if version or travis_version or travis_os or travis_language:
             monkeypatch.setenv('TRAVIS', 'true')
 
         if version:
@@ -114,11 +119,16 @@ class TestToxTravis:
 
             monkeypatch.setenv('__TOX_TRAVIS_SYS_VERSION', sys_version)
 
+        print('!!travis_version:', travis_version)
+
         if travis_version:
             monkeypatch.setenv('TRAVIS_PYTHON_VERSION', travis_version)
 
         if travis_os:
             monkeypatch.setenv('TRAVIS_OS_NAME', travis_os)
+
+        if travis_language:
+            monkeypatch.setenv('TRAVIS_LANGUAGE', travis_language)
 
         if isinstance(env, dict):
             for key, value in env.items():
@@ -131,13 +141,6 @@ class TestToxTravis:
             'pypy', 'pypy3', 'docs',
         ]
         assert self.tox_envs() == expected
-
-    def test_any_default(self, tmpdir, monkeypatch):
-        self.configure(tmpdir, monkeypatch, tox_ini)
-        monkeypatch.setenv('TRAVIS', 'true')
-        tox_envs = self.tox_envs()
-        assert len(tox_envs) == 1
-        assert tox_envs[0].startswith('py')
 
     def test_travis_default_26(self, tmpdir, monkeypatch):
         self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 2, 6)
@@ -243,36 +246,58 @@ class TestToxTravis:
         self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 4)
         assert self.tox_envs() == ['other']
 
-    def test_travis_factors(self, tmpdir, monkeypatch):
+    def test_travis_factors_py27(self, tmpdir, monkeypatch):
         tox_ini = tox_ini_travis_factors
         self.configure(tmpdir, monkeypatch, tox_ini, travis_version='2.7')
         assert self.tox_envs() == ['py27', 'docs']
 
+    def test_travis_factors_py35(self, tmpdir, monkeypatch):
+        tox_ini = tox_ini_travis_factors
         self.configure(tmpdir, monkeypatch, tox_ini, travis_version='3.5')
         assert self.tox_envs() == ['py35']
 
+    def test_travis_factors_osx(self, tmpdir, monkeypatch):
+        tox_ini = tox_ini_travis_factors
         self.configure(tmpdir, monkeypatch, tox_ini, travis_os='osx')
         assert self.tox_envs() == ['py27', 'py35', 'docs']
 
-        self.configure(tmpdir, monkeypatch, tox_ini, travis_version='2.7', travis_os='osx')
+    def test_travis_factors_py27_osx(self, tmpdir, monkeypatch):
+        tox_ini = tox_ini_travis_factors
+        self.configure(
+            tmpdir, monkeypatch, tox_ini,
+            travis_version='2.7', travis_os='osx')
+        assert self.tox_envs() == ['py27', 'docs']
+
+    def test_travis_factors_language(self, tmpdir, monkeypatch):
+        tox_ini = tox_ini_travis_factors
+        self.configure(
+            tmpdir, monkeypatch, tox_ini, travis_language='generic')
         assert self.tox_envs() == ['py27', 'py35', 'docs']
 
-    def test_travis_env(self, tmpdir, monkeypatch):
+    def test_travis_env_py27(self, tmpdir, monkeypatch):
         tox_ini = tox_ini_travis_env
         self.configure(tmpdir, monkeypatch, tox_ini, travis_version='2.7')
         assert self.tox_envs() == ['py27-django19', 'py27-django110']
 
-        self.configure(tmpdir, monkeypatch, tox_ini, travis_version='2.7', env={'DJANGO': '1.9'})
+    def test_travis_env_py27_dj19(self, tmpdir, monkeypatch):
+        tox_ini = tox_ini_travis_env
+        self.configure(
+            tmpdir, monkeypatch, tox_ini,
+            travis_version='2.7', env={'DJANGO': '1.9'})
         assert self.tox_envs() == ['py27-django19']
 
-        self.configure(tmpdir, monkeypatch, tox_ini, travis_version='3.5', env={'DJANGO': '1.10'})
+    def test_travis_env_py35_dj110(self, tmpdir, monkeypatch):
+        tox_ini = tox_ini_travis_env
+        self.configure(
+            tmpdir, monkeypatch, tox_ini,
+            travis_version='3.5', env={'DJANGO': '1.10'})
         assert self.tox_envs() == ['py35-django110']
 
     def test_legacy_warning(self, tmpdir, monkeypatch):
         tox_ini = tox_ini_legacy_warning
         self.configure(tmpdir, monkeypatch, tox_ini, travis_version='2.7')
 
-        with raises(AssertionError) as err:
-            self.tox_envs()
-
-        assert '[tox:travis] is a legacy section and should not be used with [travis:env]' in str(err.value)
+        _, _, stderr = self.tox_envs_raw()
+        assert (
+            'The [tox:travis] section is deprecated in favor of the '
+            '"python" key of the [travis] section.' in stderr)


### PR DESCRIPTION
Add support for `os`, `language`, and `python` Travis factors, as well as for environment factors as well.

This includes, supercedes, and ultimately fixes #34. Fixes #4, Fixes #25, and references #19.