### PR TITLE
Add tox envs for docs and desc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,11 @@ branches:
     - /^\d+(\.\d+)*$/
 matrix:
   fast_finish: true
+  include:
+  - python: 3.5
+    env: TOXENV=docs
+  - python: 3.5
+    env: TOXENV=desc
 
 deploy:
   provider: pypi
@@ -41,4 +46,5 @@ deploy:
   on:
     tags: true
     python: 3.5
+    condition: $TOXENV != docs && $TOXENV != desc
   distributions: sdist bdist_wheel

--- a/README.rst
+++ b/README.rst
@@ -211,7 +211,7 @@ that corresponds to using the above ``travis:after`` section:
       on:
         tags: true
         python: 3.5
-        condition: DJANGO = "1.8"
+        condition: $DJANGO = "1.8"
       distributions: sdist bdist_wheel
 
 This example deploys when the build is from a tag

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, docs, py32, py33, py34, py35, pypy, pypy3
+envlist = py26, py27, py32, py33, py34, py35, pypy, pypy3, docs, desc
 
 [testenv]
 # mock is required to allow mock_use_standalone_module
@@ -17,8 +17,15 @@ deps =
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
 
+[testenv:desc]
+deps =
+    docutils
+    Pygments
+commands =
+    python setup.py check --restructuredtext --strict
+
 [travis:after]
-travis = python: 3.5
+toxenv = py35
 
 [flake8]
 ignore = D203


### PR DESCRIPTION
The docs env builds the docs with sphinx. The desc env builds ensures that the long description that will be given to PyPI is valid reStructuredText. That would have avoided my issues today, where I had simply forgotten to lengthen the title of one of the sections in the HISTORY file.