### PR TITLE
Fix example .travis.yml

### DIFF
--- a/docs/toxenv.rst
+++ b/docs/toxenv.rst
@@ -69,9 +69,10 @@ For example, see the following ``.travis.yml`` and ``tox.ini``:
     env:
       - DJANGO="1.7"
       - DJANGO="1.8"
-    include:
-      - os: osx
-        language: generic
+    matrix:
+      include:
+        - os: osx
+          language: generic
     install: pip install tox-travis
     script: tox
 


### PR DESCRIPTION
According to https://docs.travis-ci.com/user/customizing-the-build, there's no `include`, just `matrix.include`.