### PR TITLE
Exit gracefully in after-all for external pull requests

### DIFF
--- a/src/tox_travis/after.py
+++ b/src/tox_travis/after.py
@@ -43,6 +43,10 @@ def travis_after():
         print('Not a Travis environment.', file=sys.stderr)
         sys.exit(UNKNOWN_ENVIRONMENT)
 
+    # after-all disabled for pull requests
+    if os.environ.get('TRAVIS_PULL_REQUEST', 'false') != 'false':
+        return
+
     if not after_config_matches():
         return  # This is not the one that needs to wait
 

--- a/tests/test_after.py
+++ b/tests/test_after.py
@@ -17,6 +17,19 @@ class TestAfter:
         out, err = capsys.readouterr()
         assert 'Not a Travis environment.' in err
 
+    def test_pull_request(self, mocker, monkeypatch, capsys):
+        """Pull requests should not run after-all."""
+        mocker.patch('tox_travis.after.after_config_matches',
+                     return_value=True)
+        monkeypatch.setenv('TRAVIS', 'true')
+        monkeypatch.setenv('TRAVIS_PULL_REQUEST', '1')
+
+        travis_after()
+
+        out, err = capsys.readouterr()
+        assert out == ''
+        assert err == ''
+
     def test_no_github_token(self, mocker, monkeypatch, capsys):
         """Raise with the right message when no github token."""
         mocker.patch('tox_travis.after.after_config_matches',


### PR DESCRIPTION
This potentially fixes #46. 