### PR TITLE
Invoke posargs correctly

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     pytest
     pytest-mock
     mock
-commands = {posargs:py.test}
+commands = py.test {posargs}
 
 [testenv:docs]
 changedir = docs


### PR DESCRIPTION
Not sure if this is just an issue on my end. If I try to do:

```sh
$ tox -e py35 -- -k TestAfter
```

I get:
```
ERROR: InvocationError: could not find executable 'k'
```

Given the current tox config, is there a correct way to pass arguments to py.test?