### PR TITLE
Remove GITHUB_TOKEN from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ python:
  - "pypy3"
  - "pypy3.3-5.2-alpha1"
  - "3.6-dev"
-env:
-  global:
-    - secure: "bGFjOxO+MSbk+iEd8ZS6toh0rzHU+MGEU8J7GUlx8k34h0paM/lzA27CG4KidI82zSBbGlwDD/GcjtRtyRkW7wg301hgUR/1+mRhszbXdFeWEwqlH/BauGXmF2EBcMrC1iiA6OP8qsDrCTM5U3d3IBgeJ8/bfAQ1SMFW2dgmjM8+kg4qokrEPiSzAowOiWImpvd6yLedCJyOSvQNu5AEOTUmaEbBOjUIdV6h9iRzwiIx1M/qgF/sUwoHNhXqtVfpOkkP46DYuUkdMsPIampEHQm94e1CuibO2mqcHYmGISLKHljBwdZu1XzKZeXM1tx325L3E6fGBYwh//vhIRI1EHc7BhqEl2NpZeoG/r+62txJovtrdYoJPMDFmgxGEOQpIph/KlU5T1mrZSWeYgeFsSVZCD/n7KO2rtgdOdoTRssoyiBmNWS9nF8EDD4gtFH0F+SIQlqL1TOUF9mTMJ4RNqXomGHjQEblm2EKMOAORkXBmwScOPzT26e/maOfclt0XIzQqRWjW5SbXmbIzsbjGyiSdPCja3Vo9xM3GAty/acsvPqEvsmxepDNf3l9MVc32KQwud6gC6Tm/DwnK772emJtBWUpyn9MLTOM+hCeYK/wDN9CRHLW38rrg2CeJtjIbPa0C+6PyO/8a2iEnqTM2lYvs59bpzuVHzzQGNkc9x8="
 
 before_install:
  # Show the current setuptools version

--- a/docs/after.rst
+++ b/docs/after.rst
@@ -13,7 +13,8 @@ There are three environment variables
 that can be used to configure this feature.
 
 * ``GITHUB_TOKEN``. This is *required*,
-  and should be encrypted in the ``.travis.yml``.
+  and should be encrypted in the ``.travis.yml``,
+  or set securely in the repository settings.
   This is used as the authentication method
   for the Travis CI API.
 * ``TRAVIS_POLLING_INTERVAL``.


### PR DESCRIPTION
It's better suited to the project Travis configuration in the web UI anyway.

https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings