### PR TITLE
[config-file] Set toxenvs in `tox_configure` instead of during parsing

### DIFF
--- a/src/tox_travis/hooks.py
+++ b/src/tox_travis/hooks.py
@@ -1,28 +1,24 @@
 """Tox hook implementations."""
 import tox
-from .utils import parser_cfg, config_cfg
 from .toxenv import default_toxenv, override_ignore_outcome
 from .after import travis_after_monkeypatch
 
 
-@tox.hookimpl(trylast=True)
 def tox_addoption(parser):
     """Add arguments and override TOXENV."""
     parser.add_argument(
         '--travis-after', dest='travis_after', action='store_true',
         help='Exit successfully after all Travis jobs complete successfully.')
 
-    cfg = parser_cfg(parser)
-    if cfg:
-        default_toxenv(cfg)
-
 
 @tox.hookimpl
 def tox_configure(config):
     """Check for the presence of the added options."""
-    cfg = config_cfg(config)
+    cfg = config._cfg
 
     if config.option.travis_after:
         travis_after_monkeypatch(cfg)
 
     override_ignore_outcome(config, cfg)
+
+    default_toxenv(cfg)

--- a/src/tox_travis/hooks.py
+++ b/src/tox_travis/hooks.py
@@ -14,11 +14,8 @@ def tox_addoption(parser):
 @tox.hookimpl
 def tox_configure(config):
     """Check for the presence of the added options."""
-    cfg = config._cfg
-
     if config.option.travis_after:
-        travis_after_monkeypatch(cfg)
+        travis_after_monkeypatch(config)
 
-    override_ignore_outcome(config, cfg)
-
-    default_toxenv(cfg)
+    override_ignore_outcome(config)
+    default_toxenv(config)

--- a/src/tox_travis/toxenv.py
+++ b/src/tox_travis/toxenv.py
@@ -14,7 +14,7 @@ except ImportError:
 from .utils import TRAVIS_FACTORS, parse_dict
 
 
-def default_toxenv(cfg):
+def default_toxenv(config):
     """Default TOXENV automatically based on the Travis environment."""
     if 'TRAVIS' not in os.environ:
         return
@@ -22,11 +22,13 @@ def default_toxenv(cfg):
     if 'TOXENV' in os.environ:
         return  # Skip any processing if already set
 
+    tox_ini = config._cfg
+
     # Find the envs that tox knows about
-    declared_envs = get_declared_envs(cfg)
+    declared_envs = get_declared_envs(tox_ini)
 
     # Find all the envs for all the desired factors given
-    desired_factors = get_desired_factors(cfg)
+    desired_factors = get_desired_factors(tox_ini)
 
     # Reduce desired factors
     desired_envs = ['-'.join(env) for env in product(*desired_factors)]
@@ -34,7 +36,7 @@ def default_toxenv(cfg):
     # Find matching envs
     matched = match_envs(declared_envs, desired_envs,
                          passthru=len(desired_factors) == 1)
-    os.environ.setdefault('TOXENV', ','.join(matched))
+    config.envlist = matched
 
     # Travis virtualenv do not provide `pypy3`, which tox tries to execute.
     # This doesnt affect Travis python version `pypy3`, as the pyenv pypy3
@@ -214,12 +216,13 @@ def env_matches(declared, desired):
     return all(factor in declared_factors for factor in desired_factors)
 
 
-def override_ignore_outcome(config, cfg):
+def override_ignore_outcome(config):
     """Override ignore_outcome if unignore_outcomes is set to True."""
     if 'TRAVIS' not in os.environ:
         return
 
-    travis_reader = SectionReader("travis", cfg)
+    tox_ini = config._cfg
+    travis_reader = SectionReader("travis", tox_ini)
     if travis_reader.getbool('unignore_outcomes', False):
         for env in config.envlist:
             config.envconfigs[env].ignore_outcome = False

--- a/src/tox_travis/utils.py
+++ b/src/tox_travis/utils.py
@@ -1,7 +1,4 @@
 """Shared constants and utility functions."""
-import sys
-import os
-import py
 
 # Mapping Travis factors to the associated env variables
 TRAVIS_FACTORS = {
@@ -33,48 +30,3 @@ def parse_dict(value):
     lines = [line.strip() for line in value.strip().splitlines()]
     pairs = [line.split(':', 1) for line in lines if line]
     return dict((k.strip(), v.strip()) for k, v in pairs)
-
-
-def parser_cfg(parser):
-    """Get an IniConfig from the parser.
-
-    Use the same method to parse the arguments that Tox does.
-    Needs to have all of the options added, or else the
-    parsing may not work in some cases. Even when adding
-    ``trylast=True`` to the hook implementation, that may
-    still happen if other used plugins run first.
-
-    Figure out the configfile that Tox is going to use, and
-    create a ``py.iniconfig.IniConfig`` from that file, or
-    ``None`` if no configuration file could be found.
-    """
-    try:
-        option = parser._parse_args(sys.argv[1:])
-    except:
-        option = None
-
-    # File finding algorithm copied from Tox
-    # Except for the default basename.
-    basename = option.configfile if option else 'tox.ini'
-    if os.path.isabs(basename):
-        inipath = py.path.local(basename)
-    else:
-        for path in py.path.local().parts(reverse=True):
-            inipath = path.join(basename)
-            if inipath.check():
-                break
-        else:
-            inipath = py.path.local().join('setup.cfg')
-            if not inipath.check():
-                return  # We couldn't find a config
-
-    return py.iniconfig.IniConfig(inipath)
-
-
-def config_cfg(config):
-    """Get the IniConfig from the Tox config.
-
-    The Tox config is it's own wrapper around ``IniConfig`` from
-    ``py``. Get the underlying ``IniConfig`` from the config.
-    """
-    return config._cfg

--- a/src/tox_travis/utils.py
+++ b/src/tox_travis/utils.py
@@ -2,7 +2,6 @@
 import sys
 import os
 import py
-import tox.config
 
 # Mapping Travis factors to the associated env variables
 TRAVIS_FACTORS = {
@@ -79,8 +78,3 @@ def config_cfg(config):
     ``py``. Get the underlying ``IniConfig`` from the config.
     """
     return config._cfg
-
-
-def get_section(section, cfg):
-    """Get a section reader for the specified section."""
-    return tox.config.SectionReader(section, cfg)

--- a/tests/test_toxenv.py
+++ b/tests/test_toxenv.py
@@ -7,7 +7,7 @@ import subprocess
 
 tox_ini = b"""
 [tox]
-envlist = py26, py27, py32, py33, py34, pypy, pypy3, docs
+envlist = py26, py27, py32, py33, py34, py35, pypy, pypy3, docs
 """
 
 tox_ini_override = tox_ini + b"""
@@ -180,7 +180,7 @@ class TestToxEnv:
         """Test the results if it's not on a Travis worker."""
         self.configure(tmpdir, monkeypatch, tox_ini)
         expected = [
-            'py26', 'py27', 'py32', 'py33', 'py34',
+            'py26', 'py27', 'py32', 'py33', 'py34', 'py35',
             'pypy', 'pypy3', 'docs',
         ]
         assert self.tox_envs() == expected

--- a/tests/test_toxenv.py
+++ b/tests/test_toxenv.py
@@ -103,13 +103,21 @@ unignore_outcomes = False
 """
 
 
+ERROR_FMT = """Tox process error
+stdout:
+%s
+stderr:
+%s
+"""
+
+
 class TestToxEnv:
     """Test the logic to automatically configure TOXENV with Travis."""
 
     def tox_envs(self):
         """Find the envs that tox sees."""
         returncode, stdout, stderr = self.tox_envs_raw()
-        assert returncode == 0, stderr
+        assert returncode == 0, ERROR_FMT % (stdout, stderr)
         return [env for env in stdout.strip().split('\n')]
 
     def tox_envs_raw(self):


### PR DESCRIPTION
@ryanhiebert - I'll add comments later, just wanted to submit this. I tried to break the changes into discrete commits so that it's a little easier to review. 

Note that this PR hinges on being able to change `default_toxenv` to be called from `tox_configure` instead of `tox_addoption`. The tests largely seem to work, minus a few issues (also see the last commit).